### PR TITLE
fixing issue https://github.com/Zerbinati/SugaR/issues/89

### DIFF
--- a/source/evaluate.cpp
+++ b/source/evaluate.cpp
@@ -23,6 +23,7 @@
 #include <cstring>   // For std::memset
 #include <iomanip>
 #include <sstream>
+#include <cmath>
 
 #include "bitboard.h"
 #include "evaluate.h"


### PR DESCRIPTION
With the fix in evaluate.cpp the compile error on OSX as described by issue #89 goes away.

### proof:
`make build ARCH=x86-64-modern`

> Config:
> debug: 'no'
> sanitize: 'no'
> optimize: 'yes'
> arch: 'x86_64'
> bits: '64'
> kernel: 'Darwin'
> os: ''
> prefetch: 'yes'
> popcnt: 'yes'
> sse: 'yes'
> pext: 'no'

> Flags:
> CXX: g++
> CXXFLAGS: -Wall -Wcast-qual -fno-exceptions -std=c++11  -pedantic -Wextra -Wshadow -m64 -arch x86_64 -mmacosx-version-min=10.9 -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -flto
> LDFLAGS: -L/usr/local/opt/openssl/lib  -m64 -arch x86_64 -mmacosx-version-min=10.9 -lpthread -Wall -Wcast-qual -fno-exceptions -std=c++11  -pedantic -Wextra -Wshadow -m64 -arch x86_64 -mmacosx-version-min=10.9 -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -flto
> 
> Testing config sanity. If this fails, try 'make help' ...
> 
> /Applications/Xcode.app/Contents/Developer/usr/bin/make ARCH=x86-64-modern COMP=gcc all
> g++ -Wall -Wcast-qual -fno-exceptions -std=c++11  -pedantic -Wextra -Wshadow -m64 -arch x86_64 -mmacosx-version-min=10.9 -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -flto -I/usr/local/opt/openssl/include  -c -o benchmark.o benchmark.cpp
> g++ -Wall -Wcast-qual -fno-exceptions -std=c++11  -pedantic -Wextra -Wshadow -m64 -arch x86_64 -mmacosx-version-min=10.9 -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -flto -I/usr/local/opt/openssl/include  -c -o bitbase.o bitbase.cpp
> g++ -Wall -Wcast-qual -fno-exceptions -std=c++11  -pedantic -Wextra -Wshadow -m64 -arch x86_64 -mmacosx-version-min=10.9 -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -flto -I/usr/local/opt/openssl/include  -c -o bitboard.o bitboard.cpp
> g++ -Wall -Wcast-qual -fno-exceptions -std=c++11  -pedantic -Wextra -Wshadow -m64 -arch x86_64 -mmacosx-version-min=10.9 -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -flto -I/usr/local/opt/openssl/include  -c -o book.o book.cpp
> g++ -Wall -Wcast-qual -fno-exceptions -std=c++11  -pedantic -Wextra -Wshadow -m64 -arch x86_64 -mmacosx-version-min=10.9 -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -flto -I/usr/local/opt/openssl/include  -c -o endgame.o endgame.cpp
> g++ -Wall -Wcast-qual -fno-exceptions -std=c++11  -pedantic -Wextra -Wshadow -m64 -arch x86_64 -mmacosx-version-min=10.9 -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -flto -I/usr/local/opt/openssl/include  -c -o evaluate.o evaluate.cpp
> evaluate.cpp:195:19: warning: unused variable 'BishopScores' [-Wunused-const-variable]
>   constexpr Score BishopScores = S(+20, +10);
>                   ^
> 1 warning generated.
> g++ -Wall -Wcast-qual -fno-exceptions -std=c++11  -pedantic -Wextra -Wshadow -m64 -arch x86_64 -mmacosx-version-min=10.9 -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -flto -I/usr/local/opt/openssl/include  -c -o main.o main.cpp
> g++ -Wall -Wcast-qual -fno-exceptions -std=c++11  -pedantic -Wextra -Wshadow -m64 -arch x86_64 -mmacosx-version-min=10.9 -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -flto -I/usr/local/opt/openssl/include  -c -o material.o material.cpp
> g++ -Wall -Wcast-qual -fno-exceptions -std=c++11  -pedantic -Wextra -Wshadow -m64 -arch x86_64 -mmacosx-version-min=10.9 -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -flto -I/usr/local/opt/openssl/include  -c -o misc.o misc.cpp
> g++ -Wall -Wcast-qual -fno-exceptions -std=c++11  -pedantic -Wextra -Wshadow -m64 -arch x86_64 -mmacosx-version-min=10.9 -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -flto -I/usr/local/opt/openssl/include  -c -o movegen.o movegen.cpp
> g++ -Wall -Wcast-qual -fno-exceptions -std=c++11  -pedantic -Wextra -Wshadow -m64 -arch x86_64 -mmacosx-version-min=10.9 -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -flto -I/usr/local/opt/openssl/include  -c -o movepick.o movepick.cpp
> g++ -Wall -Wcast-qual -fno-exceptions -std=c++11  -pedantic -Wextra -Wshadow -m64 -arch x86_64 -mmacosx-version-min=10.9 -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -flto -I/usr/local/opt/openssl/include  -c -o pawns.o pawns.cpp
> g++ -Wall -Wcast-qual -fno-exceptions -std=c++11  -pedantic -Wextra -Wshadow -m64 -arch x86_64 -mmacosx-version-min=10.9 -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -flto -I/usr/local/opt/openssl/include  -c -o position.o position.cpp
> g++ -Wall -Wcast-qual -fno-exceptions -std=c++11  -pedantic -Wextra -Wshadow -m64 -arch x86_64 -mmacosx-version-min=10.9 -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -flto -I/usr/local/opt/openssl/include  -c -o psqt.o psqt.cpp
> g++ -Wall -Wcast-qual -fno-exceptions -std=c++11  -pedantic -Wextra -Wshadow -m64 -arch x86_64 -mmacosx-version-min=10.9 -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -flto -I/usr/local/opt/openssl/include  -c -o search.o search.cpp
> g++ -Wall -Wcast-qual -fno-exceptions -std=c++11  -pedantic -Wextra -Wshadow -m64 -arch x86_64 -mmacosx-version-min=10.9 -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -flto -I/usr/local/opt/openssl/include  -c -o thread.o thread.cpp
> g++ -Wall -Wcast-qual -fno-exceptions -std=c++11  -pedantic -Wextra -Wshadow -m64 -arch x86_64 -mmacosx-version-min=10.9 -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -flto -I/usr/local/opt/openssl/include  -c -o timeman.o timeman.cpp
> g++ -Wall -Wcast-qual -fno-exceptions -std=c++11  -pedantic -Wextra -Wshadow -m64 -arch x86_64 -mmacosx-version-min=10.9 -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -flto -I/usr/local/opt/openssl/include  -c -o tt.o tt.cpp
> g++ -Wall -Wcast-qual -fno-exceptions -std=c++11  -pedantic -Wextra -Wshadow -m64 -arch x86_64 -mmacosx-version-min=10.9 -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -flto -I/usr/local/opt/openssl/include  -c -o uci.o uci.cpp
> g++ -Wall -Wcast-qual -fno-exceptions -std=c++11  -pedantic -Wextra -Wshadow -m64 -arch x86_64 -mmacosx-version-min=10.9 -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -flto -I/usr/local/opt/openssl/include  -c -o ucioption.o ucioption.cpp
> ucioption.cpp:46:35: warning: unused parameter 'o' [-Wunused-parameter]
> void on_large_pages(const Option& o) { TT.resize(0); }  // warning is ok, will be removed
>                                   ^
> 1 warning generated.
> g++ -Wall -Wcast-qual -fno-exceptions -std=c++11  -pedantic -Wextra -Wshadow -m64 -arch x86_64 -mmacosx-version-min=10.9 -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -flto -I/usr/local/opt/openssl/include  -c -o polybook.o polybook.cpp
> g++ -Wall -Wcast-qual -fno-exceptions -std=c++11  -pedantic -Wextra -Wshadow -m64 -arch x86_64 -mmacosx-version-min=10.9 -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -flto -I/usr/local/opt/openssl/include  -c -o syzygy/tbprobe.o syzygy/tbprobe.cpp
> g++ -o sugar benchmark.o bitbase.o bitboard.o book.o endgame.o evaluate.o main.o material.o misc.o movegen.o movepick.o pawns.o position.o psqt.o search.o thread.o timeman.o tt.o uci.o ucioption.o polybook.o syzygy/tbprobe.o -L/usr/local/opt/openssl/lib  -m64 -arch x86_64 -mmacosx-version-min=10.9 -lpthread -Wall -Wcast-qual -fno-exceptions -std=c++11  -pedantic -Wextra -Wshadow -m64 -arch x86_64 -mmacosx-version-min=10.9 -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -flto  -m64 -arch x86_64 -mmacosx-version-min=10.9 -lpthread -Wall -Wcast-qual -fno-exceptions -std=c++11  -pedantic -Wextra -Wshadow -m64 -arch x86_64 -mmacosx-version-min=10.9 -DNDEBUG -O3 -mdynamic-no-pic -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -flto

--- Voila: no errors, SugaR builds fine.

### Test:
`./sugar bench`
[stuff omitted ...]
===========================
Total time (ms) : 2821
Nodes searched  : 4900012
Nodes/second    : 1736976

best regards,
OJG