### PR TITLE
Fixes Issue "tt.cpp does not compile on non-windows platforms"

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -36,10 +36,10 @@ using std::string;
 #include "misc.h"
 #include "tt.h"
 #include "uci.h"
-#include "windows.h"
+
 
 #ifdef _WIN32
-
+#include "windows.h"
 #include <windows.h>
 #undef max
 #undef min


### PR DESCRIPTION
puts line #incude "windows.h" into the conditional windows compile path. Please confirm wether that works. I have confirmed that this is compiling and executing fine on both MacOS and Linux.

best regards,
OJ